### PR TITLE
Add password display toggle

### DIFF
--- a/app/javascript/packs/foremEmailRegistration.js
+++ b/app/javascript/packs/foremEmailRegistration.js
@@ -1,0 +1,36 @@
+function setTogglePasswordEvent(targetClass) {
+  function togglePasswordMask(event) {
+    event.preventDefault();
+    visible = !visible;
+    toggleAriaPressed(visible);
+    togglePasswordType(visible);
+    toggleEyeIcons(visible);
+  }
+
+  function toggleAriaPressed(visible) {
+    visibility.setAttribute('aria-pressed', visible);
+  }
+
+  function togglePasswordType(visible) {
+    const passwordType = visible ? 'text' : 'password';
+    passwordField.type = passwordType;
+  }
+
+  function toggleEyeIcons(visible) {
+    eyeOffIcon.classList.toggle('hidden', !visible);
+    eyeIcon.classList.toggle('hidden', visible);
+  }
+
+  let visible = false;
+  const targetWrapper = document.getElementsByClassName(targetClass)[0];
+  const eyeIcon = targetWrapper.getElementsByClassName('js-eye')[0];
+  const eyeOffIcon = targetWrapper.getElementsByClassName('js-eye-off')[0];
+  const passwordField = targetWrapper.getElementsByClassName('js-password')[0];
+  const visibility = targetWrapper.getElementsByClassName(
+    'js-creator-password-visibility',
+  )[0];
+  visibility.addEventListener('click', togglePasswordMask);
+}
+
+setTogglePasswordEvent('js-password-wrapper');
+setTogglePasswordEvent('js-password-confirmation-wrapper');

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_packs_with_chunks_tag "foremEmailRegistration", defer: true %>
+
 <div id="sign-in-password-form" class="mt-8 mb-6 crayons-card p-7 align-left mx-auto" style="max-width:580px;">
   <% if flash[:notice] %>
     <div class="crayons-notice crayons-notice--danger mb-6" role="alert">
@@ -78,7 +80,13 @@
         <%= t("views.auth.register.field.password.label") %>
         <span class="crayons-field__required crayons-hover-tooltip" data-tooltip="<%= t("views.auth.register.field.required") %>">*</span>
       <% end %>
-      <%= f.password_field :password, autocomplete: "current-password", class: "crayons-textfield", required: true %>
+      <div class="relative js-password-wrapper">
+        <%= f.password_field :password, autocomplete: "current-password", class: "crayons-textfield js-password", required: true %>
+        <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.field.password.show") %>" aria-pressed="false">
+          <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.show")) %>
+          <%= crayons_icon_tag("eye-off", class: "hidden js-eye-off", data: { testid: "unmask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.hide")) %>
+        </button>
+      </div>
     </div>
 
     <div class="crayons-field mt-2">
@@ -86,7 +94,13 @@
         <%= t("views.auth.register.field.confirm.label") %>
         <span class="crayons-field__required crayons-hover-tooltip" data-tooltip="<%= t("views.auth.register.field.required") %>">*</span>
       <% end %>
-      <%= f.password_field :password_confirmation, autocomplete: "current-password", class: "crayons-textfield", required: true %>
+      <div class="relative js-password-confirmation-wrapper">
+        <%= f.password_field :password_confirmation, autocomplete: "current-password", class: "crayons-textfield js-password", required: true %>
+        <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.field.password.show") %>" aria-pressed="false">
+          <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.show")) %>
+          <%= crayons_icon_tag("eye-off", class: "hidden js-eye-off", data: { testid: "unmask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.hide")) %>
+        </button>
+      </div>
     </div>
 
     <% if ENV["FOREM_OWNER_SECRET"].present? && Settings::General.waiting_on_first_user %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description


## Related Tickets & Documents

- Closes 16756

## QA Instructions, Screenshots, Recordings

Added button to toggle password display as well as password form on other pages

https://user-images.githubusercontent.com/47295890/160241778-ad97d9fa-765e-46af-9048-7bf64cd6d2a4.mov


### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: Sorry, I couldn't figure out how to display this page in the test